### PR TITLE
Fix await-port deprecation

### DIFF
--- a/scripts/start_mysql.sh
+++ b/scripts/start_mysql.sh
@@ -14,8 +14,8 @@ then
     rm /var/run/mysqld/gitpod-init.lock
 fi
 
-gp await-port 3306
-gp await-port 33060
+gp ports await 3306
+gp ports await 33060
 
 # Create read user with read only privileges
 mysql -u root -e "CREATE USER IF NOT EXISTS 'read'@'localhost'; GRANT SELECT ON *.* TO 'read'@'localhost'; FLUSH PRIVILEGES;"


### PR DESCRIPTION
@vnr-csg, snelle fix voor het await-port commando die nu deprecated is:
![image](https://user-images.githubusercontent.com/43184442/186443301-2b59f0ab-e7cf-4dfb-972f-8ff52f66ee43.png)
